### PR TITLE
Implement enhanced offline sync engine

### DIFF
--- a/src/components/screens/ClockInScreen.tsx
+++ b/src/components/screens/ClockInScreen.tsx
@@ -493,6 +493,12 @@ export function ClockInScreen() {
                       {clockIn.syncStatus === 'pending' && (
                         <Badge variant="warning" size="sm">Pendiente</Badge>
                       )}
+                      {clockIn.syncStatus === 'error' && (
+                        <Badge variant="danger" size="sm">Error</Badge>
+                      )}
+                      {clockIn.syncStatus === 'conflicted' && (
+                        <Badge variant="info" size="sm">Conflicto</Badge>
+                      )}
                     </div>
                   </div>
                 );

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useReducer, useEffect, ReactNode } from 'react';
+import React, { createContext, useContext, useReducer, useEffect, ReactNode, useRef } from 'react';
 import { storageManager } from '../services/storageManager';
 import { syncEngine } from '../services/syncEngine';
 import type { UserSession, AppMode, SyncStatus, Company } from '../types';
@@ -203,6 +203,7 @@ interface AppProviderProps {
 export function AppProvider({ children }: AppProviderProps) {
   const [state, dispatch] = useReducer(appReducer, initialState);
   const navigationHistory: string[] = [];
+  const prevSyncStatusRef = useRef<SyncStatus>(syncEngine.getStatus());
 
   // ==========================================
   // INICIALIZACIÓN
@@ -251,8 +252,14 @@ export function AppProvider({ children }: AppProviderProps) {
 
   const setupEventListeners = () => {
     // Online/Offline status
-    const handleOnline = () => dispatch({ type: 'SET_ONLINE_STATUS', payload: true });
-    const handleOffline = () => dispatch({ type: 'SET_ONLINE_STATUS', payload: false });
+    const handleOnline = () => {
+      dispatch({ type: 'SET_ONLINE_STATUS', payload: true });
+      showNotification({ type: 'info', title: 'Conexión restablecida', message: 'Se reanudó la sincronización', autoClose: true });
+    };
+    const handleOffline = () => {
+      dispatch({ type: 'SET_ONLINE_STATUS', payload: false });
+      showNotification({ type: 'warning', title: 'Sin conexión', message: 'La aplicación está sin conexión' });
+    };
     
     window.addEventListener('online', handleOnline);
     window.addEventListener('offline', handleOffline);
@@ -260,6 +267,14 @@ export function AppProvider({ children }: AppProviderProps) {
     // Sync status changes
     const unsubscribeSync = syncEngine.onStatusChange((status) => {
       dispatch({ type: 'SET_SYNC_STATUS', payload: status });
+
+      const prev = prevSyncStatusRef.current;
+      if (status.errorCount > prev.errorCount) {
+        showNotification({ type: 'error', title: 'Error de sincronización', message: 'Algunos datos no pudieron sincronizarse' });
+      } else if (prev.pendingCount > 0 && status.pendingCount === 0 && !status.isProcessing) {
+        showNotification({ type: 'success', title: 'Sincronización completa', message: 'Todos los datos están sincronizados', autoClose: true });
+      }
+      prevSyncStatusRef.current = status;
     });
 
     // Cleanup

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,7 +7,7 @@ export interface BaseEntity {
   createdAt: string;
   updatedAt: string;
   version: number;
-  syncStatus: 'pending' | 'synced' | 'error';
+  syncStatus: 'pending' | 'synced' | 'error' | 'conflicted';
   isDemo?: boolean;
   companyId: string;
 }


### PR DESCRIPTION
## Summary
- extend `BaseEntity` syncStatus with new `conflicted` state
- upgrade `syncEngine` with entity status updates and pending export
- show sync error badges in `ClockInScreen`
- notify user when connection or sync status changes

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint` *(fails: Cannot read properties of undefined (reading 'allowShortCircuit'))*

------
https://chatgpt.com/codex/tasks/task_e_6863daff8aa88330be3019b2a60f6cc2