### PR TITLE
Implement demo initialization and legal reports

### DIFF
--- a/src/components/auth/LoginScreen.tsx
+++ b/src/components/auth/LoginScreen.tsx
@@ -3,7 +3,7 @@ import { LogIn, Building2, Users, Shield, Zap } from 'lucide-react';
 import { Button } from '../ui/Button';
 import { Card, CardContent } from '../ui/Card';
 import { useApp } from '../../contexts/AppContext';
-import { environmentInitializer } from '../../services/initializeDefaultEnvironment';
+import { initializeDefaultEnvironment } from '../../services/initializeDefaultEnvironment';
 
 export function LoginScreen() {
   const { login, state, showNotification } = useApp();
@@ -16,7 +16,7 @@ export function LoginScreen() {
       console.log('[LoginScreen] Starting demo login...');
       
       // Inicializar entorno demo si es necesario
-      const initResult = await environmentInitializer.initializeEnvironment();
+      const initResult = await initializeDefaultEnvironment();
       
       console.log('[LoginScreen] Init result:', initResult);
       

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -148,8 +148,13 @@ export function MainLayout({ children }: MainLayoutProps) {
                 <h1 className="text-xl font-semibold text-gray-900">
                   {state.currentCompany?.name || 'Workforce Management'}
                 </h1>
-                {state.appMode.mode === 'demo' && (
-                  <Badge variant="info" size="sm">DEMO</Badge>
+                {state.appMode.mode !== 'production' && (
+                  <Badge
+                    variant={state.appMode.mode === 'debug' ? 'danger' : 'info'}
+                    size="sm"
+                  >
+                    {state.appMode.mode.toUpperCase()}
+                  </Badge>
                 )}
               </div>
             </div>

--- a/src/components/screens/ClockInScreen.tsx
+++ b/src/components/screens/ClockInScreen.tsx
@@ -180,6 +180,14 @@ export function ClockInScreen() {
   // ==========================================
 
   const handleManualClockIn = async (stationId: string, type: 'in' | 'out') => {
+    if (state.appMode.mode === 'demo') {
+      showNotification({
+        type: 'warning',
+        title: 'Función deshabilitada',
+        message: 'El fichaje real está deshabilitado en modo demo'
+      });
+      return;
+    }
     if (!currentUser) return;
 
     const station = stations?.find(s => s.id === stationId);
@@ -235,6 +243,14 @@ export function ClockInScreen() {
   // ==========================================
 
   const processQRResult = async (type: 'in' | 'out') => {
+    if (state.appMode.mode === 'demo') {
+      showNotification({
+        type: 'warning',
+        title: 'Función deshabilitada',
+        message: 'El fichaje real está deshabilitado en modo demo'
+      });
+      return;
+    }
     if (!scanResult?.success || !scanResult.station || !currentUser) return;
 
     const clockInData = {

--- a/src/components/screens/ReportsScreen.tsx
+++ b/src/components/screens/ReportsScreen.tsx
@@ -20,6 +20,7 @@ import { Badge } from '../ui/Badge';
 import { Modal } from '../ui/Modal';
 import { useApp } from '../../contexts/AppContext';
 import { useClockIns, useUsers, useStations, useLeaveRequests } from '../../hooks/useData';
+import { legalFramework } from '../../services/legalFramework';
 
 interface ReportFilters {
   startDate: string;
@@ -213,6 +214,14 @@ export function ReportsScreen() {
   // ==========================================
 
   const handleExport = (format: 'pdf' | 'excel' | 'csv') => {
+    if (state.appMode.mode === 'demo') {
+      showNotification({
+        type: 'warning',
+        title: 'Función deshabilitada',
+        message: 'La exportación está deshabilitada en modo demo'
+      });
+      return;
+    }
     if (!reportData) return;
 
     // Simular exportación
@@ -241,6 +250,33 @@ export function ReportsScreen() {
     });
 
     setShowExportModal(false);
+  };
+
+  const handleGenerateLegalReport = () => {
+    if (state.appMode.mode === 'demo') {
+      showNotification({
+        type: 'warning',
+        title: 'Función deshabilitada',
+        message: 'No disponible en modo demo'
+      });
+      return;
+    }
+    const weekStart = filters.startDate;
+    const report = legalFramework.generateLegalReport(state.session!.company.id, weekStart);
+    if (report) {
+      showNotification({
+        type: 'success',
+        title: 'Informe legal generado',
+        message: `Semana ${report.weekStart} - ${report.weekEnd}`,
+        autoClose: true
+      });
+    } else {
+      showNotification({
+        type: 'error',
+        title: 'Error',
+        message: 'No se pudo generar el informe'
+      });
+    }
   };
 
   const resetFilters = () => {
@@ -279,13 +315,22 @@ export function ReportsScreen() {
           </p>
         </div>
         
-        <Button
-          onClick={() => setShowExportModal(true)}
-          icon={Download}
-          className="bg-blue-600 hover:bg-blue-700"
-        >
-          Exportar Reporte
-        </Button>
+        <div className="flex space-x-2">
+          <Button
+            onClick={() => setShowExportModal(true)}
+            icon={Download}
+            className="bg-blue-600 hover:bg-blue-700"
+          >
+            Exportar Reporte
+          </Button>
+          <Button
+            onClick={handleGenerateLegalReport}
+            icon={FileText}
+            className="bg-green-600 hover:bg-green-700"
+          >
+            Informe Legal
+          </Button>
+        </div>
       </div>
 
       {/* Filtros */}

--- a/src/components/screens/SettingsScreen.tsx
+++ b/src/components/screens/SettingsScreen.tsx
@@ -100,6 +100,14 @@ export function SettingsScreen() {
   };
 
   const handleExportData = (format: 'json' | 'csv') => {
+    if (state.appMode.mode === 'demo') {
+      showNotification({
+        type: 'warning',
+        title: 'Función deshabilitada',
+        message: 'La exportación está deshabilitada en modo demo'
+      });
+      return;
+    }
     try {
       const data = storageManager.exportData();
       
@@ -134,6 +142,14 @@ export function SettingsScreen() {
   };
 
   const handleImportData = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (state.appMode.mode === 'demo') {
+      showNotification({
+        type: 'warning',
+        title: 'Función deshabilitada',
+        message: 'La importación está deshabilitada en modo demo'
+      });
+      return;
+    }
     const file = event.target.files?.[0];
     if (!file) return;
 

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useReducer, useEffect, ReactNode } from 'react';
 import { storageManager } from '../services/storageManager';
 import { syncEngine } from '../services/syncEngine';
+import { legalFramework } from '../services/legalFramework';
 import type { UserSession, AppMode, SyncStatus, Company } from '../types';
 
 // ==========================================
@@ -222,6 +223,7 @@ export function AppProvider({ children }: AppProviderProps) {
       const savedAppMode = storageManager.get<AppMode>('wmapp_mode');
       if (savedAppMode) {
         dispatch({ type: 'SET_APP_MODE', payload: savedAppMode });
+        console.log('[AppProvider] Mode:', savedAppMode.mode);
       }
 
       // Cargar sesión guardada
@@ -332,6 +334,8 @@ export function AppProvider({ children }: AppProviderProps) {
       };
 
       console.log('[AppProvider] Session created successfully');
+
+      legalFramework.recordConsent(user.id);
 
       // Guardar sesión
       storageManager.set('wmapp_session', session);

--- a/src/services/initializeDefaultEnvironment.ts
+++ b/src/services/initializeDefaultEnvironment.ts
@@ -145,7 +145,8 @@ class EnvironmentInitializer {
       isDemo: true,
       isActive: true,
       currency: 'EUR',
-      startDate: '2024-01-01'
+      startDate: '2024-01-01',
+      nationalId: '00000000A'
     };
 
     const users: User[] = [
@@ -156,37 +157,16 @@ class EnvironmentInitializer {
         firstName: 'Ana',
         lastName: 'García',
         role: 'admin',
-        stationIds: ['demo_station_001', 'demo_station_002'],
+        stationIds: ['demo_station_001'],
         avatar: 'https://images.pexels.com/photos/774909/pexels-photo-774909.jpeg?auto=compress&cs=tinysrgb&w=200',
         phoneNumber: '+34 600 123 456',
+        nationalId: '00000001A',
         department: 'Administración',
         position: 'Directora General',
         salary: 45000,
         passwordHash: '5d41402abc4b2a76b9719d911017c592', // Hash fijo para 'hello'
         permissions: [
           { resource: '*', actions: ['create', 'read', 'update', 'delete', 'approve'] }
-        ]
-      },
-      {
-        ...baseUser,
-        id: 'demo_manager_001',
-        email: 'manager@demo.com',
-        firstName: 'Carlos',
-        lastName: 'Rodríguez',
-        role: 'manager',
-        stationIds: ['demo_station_001'],
-        avatar: 'https://images.pexels.com/photos/220453/pexels-photo-220453.jpeg?auto=compress&cs=tinysrgb&w=200',
-        phoneNumber: '+34 600 234 567',
-        department: 'Operaciones',
-        position: 'Jefe de Operaciones',
-        salary: 35000,
-        passwordHash: '5d41402abc4b2a76b9719d911017c592',
-        permissions: [
-          { resource: 'users', actions: ['read', 'update'] },
-          { resource: 'clockins', actions: ['read', 'update', 'approve'] },
-          { resource: 'leaves', actions: ['read', 'approve'] },
-          { resource: 'stations', actions: ['read'] },
-          { resource: 'reports', actions: ['read'] }
         ]
       },
       {
@@ -199,6 +179,7 @@ class EnvironmentInitializer {
         stationIds: ['demo_station_001'],
         avatar: 'https://images.pexels.com/photos/415829/pexels-photo-415829.jpeg?auto=compress&cs=tinysrgb&w=200',
         phoneNumber: '+34 600 345 678',
+        nationalId: '00000002B',
         department: 'Ventas',
         position: 'Comercial',
         salary: 28000,
@@ -216,9 +197,10 @@ class EnvironmentInitializer {
         firstName: 'David',
         lastName: 'Martín',
         role: 'employee',
-        stationIds: ['demo_station_002'],
+        stationIds: ['demo_station_001'],
         avatar: 'https://images.pexels.com/photos/1222271/pexels-photo-1222271.jpeg?auto=compress&cs=tinysrgb&w=200',
         phoneNumber: '+34 600 456 789',
+        nationalId: '00000003C',
         department: 'Almacén',
         position: 'Operario',
         salary: 24000,
@@ -255,44 +237,12 @@ class EnvironmentInitializer {
           isTemporary: false
         },
         isActive: true,
-        allowedUserIds: ['demo_admin_001', 'demo_manager_001', 'demo_employee_001'],
+        allowedUserIds: ['demo_admin_001', 'demo_employee_001', 'demo_employee_002'],
         description: 'Punto de fichaje principal del edificio',
         stationType: 'entrance',
         restrictions: {
           timeWindows: [
             { start: '07:00', end: '20:00', days: [1, 2, 3, 4, 5] }
-          ]
-        },
-        createdAt: now,
-        updatedAt: now,
-        version: 1,
-        syncStatus: 'synced',
-        isDemo: true,
-        companyId
-      },
-      {
-        id: 'demo_station_002',
-        name: 'Almacén',
-        location: {
-          lat: 40.4170,
-          lng: -3.7040,
-          address: 'Almacén - Planta Baja'
-        },
-        qrCode: await qrEngine.generateStationQR('demo_station_002', companyId),
-        qrMetadata: {
-          stationId: 'demo_station_002',
-          companyId,
-          timestamp: now,
-          version: '1.0',
-          isTemporary: false
-        },
-        isActive: true,
-        allowedUserIds: ['demo_admin_001', 'demo_employee_002'],
-        description: 'Punto de fichaje del almacén',
-        stationType: 'warehouse',
-        restrictions: {
-          timeWindows: [
-            { start: '08:00', end: '17:00', days: [1, 2, 3, 4, 5] }
           ]
         },
         createdAt: now,
@@ -544,3 +494,7 @@ class EnvironmentInitializer {
 
 // Singleton instance
 export const environmentInitializer = new EnvironmentInitializer();
+
+export async function initializeDefaultEnvironment() {
+  return environmentInitializer.initializeEnvironment();
+}

--- a/src/services/legalFramework.ts
+++ b/src/services/legalFramework.ts
@@ -1,0 +1,83 @@
+import { storageManager } from './storageManager';
+import { STORAGE_KEYS, ConsentRecord, LegalReport, User, Company, ClockIn } from '../types';
+
+class LegalFramework {
+  recordConsent(userId: string): void {
+    const records = storageManager.get<ConsentRecord[]>(STORAGE_KEYS.CONSENTS, []);
+    const existing = records.find(r => r.userId === userId);
+    if (!existing) {
+      const now = new Date().toISOString();
+      records.push({
+        id: `${userId}_${now}`,
+        userId,
+        consentGivenAt: now,
+        createdAt: now,
+        updatedAt: now,
+        version: 1,
+        syncStatus: 'synced',
+        companyId: ''
+      });
+      storageManager.set(STORAGE_KEYS.CONSENTS, records);
+    }
+  }
+
+  generateLegalReport(companyId: string, weekStart: string): LegalReport | null {
+    try {
+      const companies = storageManager.get<Company[]>(STORAGE_KEYS.COMPANIES, []);
+      const company = companies.find(c => c.id === companyId);
+      if (!company) return null;
+
+      const users = storageManager.get<User[]>(STORAGE_KEYS.USERS, []).filter(u => u.companyId === companyId);
+      const clockIns = storageManager.get<ClockIn[]>(STORAGE_KEYS.CLOCKINS, []).filter(c => c.companyId === companyId);
+
+      const start = new Date(weekStart);
+      const end = new Date(start);
+      end.setDate(start.getDate() + 6);
+      const startISO = start.toISOString().split('T')[0];
+      const endISO = end.toISOString().split('T')[0];
+
+      const weeklyClockIns = clockIns.filter(c => c.timestamp >= `${startISO}T00:00:00` && c.timestamp <= `${endISO}T23:59:59`);
+
+      const entries = users.map(u => {
+        const records = weeklyClockIns.filter(c => c.userId === u.id).map(c => ({ type: c.type, timestamp: c.timestamp }));
+        return {
+          userId: u.id,
+          userName: `${u.firstName} ${u.lastName}`,
+          nationalId: u.nationalId,
+          records
+        };
+      });
+
+      const now = new Date().toISOString();
+      const report: LegalReport = {
+        id: `report_${now}`,
+        companyId,
+        weekStart: startISO,
+        weekEnd: endISO,
+        companyName: company.name,
+        companyTaxId: company.taxId,
+        entries,
+        generatedAt: now,
+        digitalSignature: btoa(now),
+        createdAt: now,
+        updatedAt: now,
+        version: 1,
+        syncStatus: 'synced'
+      };
+
+      const stored = storageManager.get<LegalReport[]>(STORAGE_KEYS.LEGAL_REPORTS, []);
+      stored.push(report);
+      storageManager.set(STORAGE_KEYS.LEGAL_REPORTS, stored);
+      return report;
+    } catch {
+      return null;
+    }
+  }
+
+  getReports(companyId: string): LegalReport[] {
+    const all = storageManager.get<LegalReport[]>(STORAGE_KEYS.LEGAL_REPORTS, []);
+    return all.filter(r => r.companyId === companyId);
+  }
+}
+
+export const legalFramework = new LegalFramework();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,6 +21,7 @@ export interface User extends BaseEntity {
   isActive: boolean;
   avatar?: string;
   phoneNumber?: string;
+  nationalId?: string;
   department?: string;
   position?: string;
   startDate: string;
@@ -37,6 +38,7 @@ export interface Company extends BaseEntity {
   name: string;
   logo?: string;
   address: string;
+  taxId?: string;
   timezone: string;
   locale: string;
   currency: string;
@@ -172,6 +174,27 @@ export interface LocalClockIn extends ClockIn {
   syncError?: string;
 }
 
+export interface ConsentRecord extends BaseEntity {
+  userId: string;
+  consentGivenAt: string;
+}
+
+export interface LegalReport extends BaseEntity {
+  companyId: string;
+  weekStart: string;
+  weekEnd: string;
+  companyName: string;
+  companyTaxId?: string;
+  entries: Array<{
+    userId: string;
+    userName: string;
+    nationalId?: string;
+    records: Array<{ type: 'in' | 'out'; timestamp: string; }>;
+  }>;
+  generatedAt: string;
+  digitalSignature: string;
+}
+
 export interface AppMode {
   mode: 'demo' | 'production' | 'debug';
   features: {
@@ -279,6 +302,8 @@ export const STORAGE_KEYS = {
   APP_MODE: 'wmapp_mode',
   SYNC_QUEUE: 'wmapp_sync_queue',
   SETTINGS: 'wmapp_settings',
+  CONSENTS: 'wmapp_consents',
+  LEGAL_REPORTS: 'wmapp_legal_reports',
 } as const;
 
 export const DEFAULT_PERMISSIONS: Record<User['role'], Permission[]> = {


### PR DESCRIPTION
## Summary
- add legalFramework service for consent recording and legal report generation
- expose initializeDefaultEnvironment wrapper
- show active mode badge for all modes
- disable export and clockin actions in demo mode
- log app mode and record consent on login
- add legal report generation button
- update demo data to 3 employees and 1 station
- extend data models with IDs and legal record storage

## Testing
- `npm run lint` *(fails: TypeError in eslint rule)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863e06c1c8c8330aee53379fe84e88f