### PR TITLE
Add internationalization engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,12 @@
       "name": "vite-react-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "i18next": "^25.3.0",
+        "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-i18next": "^15.5.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
@@ -288,6 +291,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2516,6 +2528,55 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.3.0.tgz",
+      "integrity": "sha512-ZSQIiNGfqSG6yoLHaCvrkPp16UejHI8PCDxFYaNG/1qxtmqNmqEg4JlWKlxkrUmrin2sEjsy+Mjy1TRozBhOgw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.0.tgz",
+      "integrity": "sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3271,6 +3332,32 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.5.3",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.5.3.tgz",
+      "integrity": "sha512-ypYmOKOnjqPEJZO4m1BI0kS8kWqkBNsKYyhVUfij0gvjy9xJNoG/VcGkxq5dRlVwzmrmY1BQMAmpbbUBLwC4Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -3727,7 +3814,7 @@
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3861,6 +3948,15 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "i18next": "^25.3.0",
+    "i18next-browser-languagedetector": "^8.2.0",
+    "react-i18next": "^15.5.3",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/src/components/screens/DashboardScreen.tsx
+++ b/src/components/screens/DashboardScreen.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { 
   Clock, 
   Users, 
@@ -17,6 +18,7 @@ import { useClockIns, useUsers, useLeaveRequests, useStations } from '../../hook
 
 export function DashboardScreen() {
   const { state, navigateTo } = useApp();
+  const { t } = useTranslation();
   const { data: clockIns, loading: clockInsLoading } = useClockIns();
   const { data: users, loading: usersLoading } = useUsers();
   const { data: leaveRequests, loading: leavesLoading } = useLeaveRequests();
@@ -63,9 +65,9 @@ export function DashboardScreen() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
+          <h1 className="text-2xl font-bold text-gray-900">{t('dashboard.title')}</h1>
           <p className="text-gray-600">
-            Bienvenido, {state.session?.user.firstName} {state.session?.user.lastName}
+            {t('dashboard.welcome', { firstName: state.session?.user.firstName, lastName: state.session?.user.lastName })}
           </p>
         </div>
         <div className="text-right">
@@ -90,7 +92,7 @@ export function DashboardScreen() {
             </div>
             <div>
               <p className="text-sm font-medium text-gray-600">
-                {userRole === 'employee' ? 'Mis Fichajes Hoy' : 'Fichajes Hoy'}
+                {userRole === 'employee' ? t('dashboard.todayClockIns.user') : t('dashboard.todayClockIns.all')}
               </p>
               <p className="text-2xl font-bold text-gray-900">
                 {userRole === 'employee' 
@@ -110,7 +112,7 @@ export function DashboardScreen() {
                 <Users className="w-6 h-6 text-green-600" />
               </div>
               <div>
-                <p className="text-sm font-medium text-gray-600">Empleados Activos</p>
+                <p className="text-sm font-medium text-gray-600">{t('dashboard.activeEmployees')}</p>
                 <p className="text-2xl font-bold text-gray-900">{activeUsers.length}</p>
               </div>
             </CardContent>
@@ -125,7 +127,7 @@ export function DashboardScreen() {
             </div>
             <div>
               <p className="text-sm font-medium text-gray-600">
-                {userRole === 'employee' ? 'Mis Solicitudes' : 'Solicitudes Pendientes'}
+                {userRole === 'employee' ? t('dashboard.pendingLeaves') : t('dashboard.pendingLeaves')}
               </p>
               <p className="text-2xl font-bold text-gray-900">
                 {userRole === 'employee' 

--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -1,0 +1,12 @@
+{
+  "dashboard": {
+    "title": "لوحة التحكم",
+    "welcome": "مرحباً، {{firstName}} {{lastName}}",
+    "todayClockIns": {
+      "user": "سجلاتي اليوم",
+      "all": "سجلات اليوم"
+    },
+    "activeEmployees": "الموظفون النشطون",
+    "pendingLeaves": "إجازات معلقة"
+  }
+}

--- a/src/i18n/bn.json
+++ b/src/i18n/bn.json
@@ -1,0 +1,12 @@
+{
+  "dashboard": {
+    "title": "ড্যাশবোর্ড",
+    "welcome": "স্বাগতম, {{firstName}} {{lastName}}",
+    "todayClockIns": {
+      "user": "আজকের আমার চেক-ইন",
+      "all": "আজকের চেক-ইন"
+    },
+    "activeEmployees": "সক্রিয় কর্মচারী",
+    "pendingLeaves": "মুলতুবি ছুটি"
+  }
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,12 @@
+{
+  "dashboard": {
+    "title": "Dashboard",
+    "welcome": "Welcome, {{firstName}} {{lastName}}",
+    "todayClockIns": {
+      "user": "My Clock-ins Today",
+      "all": "Clock-ins Today"
+    },
+    "activeEmployees": "Active Employees",
+    "pendingLeaves": "Pending Leaves"
+  }
+}

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,0 +1,12 @@
+{
+  "dashboard": {
+    "title": "Tablero",
+    "welcome": "Bienvenido, {{firstName}} {{lastName}}",
+    "todayClockIns": {
+      "user": "Mis Fichajes Hoy",
+      "all": "Fichajes Hoy"
+    },
+    "activeEmployees": "Empleados Activos",
+    "pendingLeaves": "Solicitudes Pendientes"
+  }
+}

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1,0 +1,12 @@
+{
+  "dashboard": {
+    "title": "Tableau de bord",
+    "welcome": "Bienvenue, {{firstName}} {{lastName}}",
+    "todayClockIns": {
+      "user": "Mes pointages aujourd'hui",
+      "all": "Pointages aujourd'hui"
+    },
+    "activeEmployees": "Employés actifs",
+    "pendingLeaves": "Congés en attente"
+  }
+}

--- a/src/i18n/hi.json
+++ b/src/i18n/hi.json
@@ -1,0 +1,12 @@
+{
+  "dashboard": {
+    "title": "डैशबोर्ड",
+    "welcome": "स्वागत है, {{firstName}} {{lastName}}",
+    "todayClockIns": {
+      "user": "आज की मेरी उपस्थिति",
+      "all": "आज की उपस्थिति"
+    },
+    "activeEmployees": "सक्रिय कर्मचारी",
+    "pendingLeaves": "लंबित अवकाश"
+  }
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,44 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+
+import en from './en.json';
+import es from './es.json';
+import fr from './fr.json';
+import bn from './bn.json';
+import hi from './hi.json';
+import ar from './ar.json';
+import zhTW from './zh-TW.json';
+import ptBR from './pt-BR.json';
+
+const resources = {
+  en: { translation: en },
+  es: { translation: es },
+  fr: { translation: fr },
+  bn: { translation: bn },
+  hi: { translation: hi },
+  ar: { translation: ar },
+  'zh-TW': { translation: zhTW },
+  'pt-BR': { translation: ptBR },
+};
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources,
+    fallbackLng: 'en',
+    interpolation: { escapeValue: false },
+    detection: {
+      order: ['navigator'],
+      caches: [],
+    },
+  });
+
+const rtlLanguages = ['ar'];
+
+i18n.on('languageChanged', (lng) => {
+  document.documentElement.dir = rtlLanguages.includes(lng) ? 'rtl' : 'ltr';
+});
+
+export default i18n;

--- a/src/i18n/pt-BR.json
+++ b/src/i18n/pt-BR.json
@@ -1,0 +1,12 @@
+{
+  "dashboard": {
+    "title": "Painel",
+    "welcome": "Bem-vindo, {{firstName}} {{lastName}}",
+    "todayClockIns": {
+      "user": "Meus registros de hoje",
+      "all": "Registros de hoje"
+    },
+    "activeEmployees": "Funcionários ativos",
+    "pendingLeaves": "Férias pendentes"
+  }
+}

--- a/src/i18n/zh-TW.json
+++ b/src/i18n/zh-TW.json
@@ -1,0 +1,12 @@
+{
+  "dashboard": {
+    "title": "儀表板",
+    "welcome": "歡迎，{{firstName}} {{lastName}}",
+    "todayClockIns": {
+      "user": "我的今日打卡",
+      "all": "今日打卡"
+    },
+    "activeEmployees": "活躍員工",
+    "pendingLeaves": "待批假期"
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import './i18n';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -12,6 +12,8 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
     "jsx": "react-jsx",
 
     /* Linting */

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -11,6 +11,8 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
## Summary
- add i18next, react-i18next and language detector
- configure TypeScript for JSON imports
- setup i18n resources for 8 languages
- hook i18n into app entry
- translate Dashboard header and stats labels

## Testing
- `npm run lint` *(fails: Unexpected any in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_6863e434e4888330a28c96544960aedc