### PR TITLE
Implement QRDesigner and maintenance agent

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { LeavesScreen } from './components/screens/LeavesScreen';
 import { ReportsScreen } from './components/screens/ReportsScreen';
 import { NotificationsScreen } from './components/screens/NotificationsScreen';
 import { SettingsScreen } from './components/screens/SettingsScreen';
+import { QRDesignerScreen } from './components/screens/QRDesignerScreen';
 
 // ==========================================
 // COMPONENTE PRINCIPAL DE LA APLICACIÓN
@@ -51,6 +52,8 @@ function AppContent() {
         return <LeavesScreen />;
       case 'reports':
         return <ReportsScreen />;
+      case 'qrdesigner':
+        return <QRDesignerScreen />;
       case 'settings':
         return <SettingsScreen />;
       case 'notifications':

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -4,9 +4,10 @@ import {
   Clock, 
   Users, 
   MapPin, 
-  Calendar, 
-  BarChart3, 
-  Settings, 
+  Calendar,
+  BarChart3,
+  QrCode,
+  Settings,
   LogOut,
   Bell,
   Menu,
@@ -31,6 +32,7 @@ export function MainLayout({ children }: MainLayoutProps) {
     { name: 'Estaciones', icon: MapPin, screen: 'stations', roles: ['admin', 'manager'] },
     { name: 'Ausencias', icon: Calendar, screen: 'leaves', roles: ['admin', 'manager', 'employee'] },
     { name: 'Reportes', icon: BarChart3, screen: 'reports', roles: ['admin', 'manager'] },
+    { name: 'QR Designer', icon: QrCode, screen: 'qrdesigner', roles: ['admin', 'manager'] },
     { name: 'Configuración', icon: Settings, screen: 'settings', roles: ['admin', 'manager', 'employee'] },
   ];
 

--- a/src/components/screens/QRDesignerScreen.tsx
+++ b/src/components/screens/QRDesignerScreen.tsx
@@ -1,0 +1,123 @@
+import React, { useState, useEffect } from 'react';
+import { Plus, Palette } from 'lucide-react';
+import { Card, CardHeader, CardTitle, CardContent } from '../ui/Card';
+import { Button } from '../ui/Button';
+import { Input } from '../ui/Input';
+import { Textarea } from '../ui/Textarea';
+import { Modal } from '../ui/Modal';
+import { useQRTemplates, useStations } from '../../hooks/useData';
+import { useApp } from '../../contexts/AppContext';
+import type { QRTemplate } from '../../types';
+
+export function QRDesignerScreen() {
+  const { state, showNotification } = useApp();
+  const { data: templates, create, update, remove } = useQRTemplates();
+  const { data: stations } = useStations();
+  const [showModal, setShowModal] = useState(false);
+  const [editing, setEditing] = useState<QRTemplate | null>(null);
+  const [form, setForm] = useState<Partial<QRTemplate>>({
+    colors: { foreground: '#000000', background: '#ffffff' },
+    instructions: { es: '', en: '' },
+    header: '',
+    footer: '',
+    isDefault: false
+  });
+  const currentCompany = state.currentCompany;
+
+  const openCreate = () => {
+    setEditing(null);
+    setForm({
+      colors: { foreground: '#000000', background: '#ffffff' },
+      instructions: { es: '', en: '' },
+      header: '',
+      footer: '',
+      isDefault: false
+    });
+    setShowModal(true);
+  };
+
+  const saveTemplate = async () => {
+    if (!form.name || !form.stationId) {
+      showNotification({ type: 'error', title: 'Error', message: 'Completa nombre y estación' });
+      return;
+    }
+    const data: Omit<QRTemplate, keyof QRTemplate> & Partial<QRTemplate> = {
+      ...form,
+      companyId: currentCompany?.id || '',
+    } as QRTemplate;
+
+    if (editing) {
+      const res = await update(editing.id, data);
+      if (res) showNotification({ type: 'success', title: 'Actualizado', message: 'Plantilla guardada', autoClose: true });
+    } else {
+      const res = await create(data as any);
+      if (res) showNotification({ type: 'success', title: 'Creado', message: 'Plantilla creada', autoClose: true });
+    }
+    setShowModal(false);
+  };
+
+  const deleteTemplate = async (id: string) => {
+    const ok = await remove(id);
+    if (ok) showNotification({ type: 'success', title: 'Eliminado', message: 'Plantilla eliminada', autoClose: true });
+  };
+
+  const Preview = () => (
+    <div className="border rounded-lg p-4" style={{ backgroundColor: form.colors?.background || '#ffffff', color: form.colors?.foreground || '#000000' }}>
+      <div className="text-center font-semibold mb-2">{form.header}</div>
+      <div className="border h-24 flex items-center justify-center mb-2">QR</div>
+      <div className="text-center text-sm whitespace-pre-line">{form.instructions?.es}</div>
+      <div className="text-center mt-2 text-xs">{form.footer}</div>
+    </div>
+  );
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex justify-between items-center">
+        <h2 className="text-xl font-semibold text-gray-900">Plantillas de QR</h2>
+        <Button icon={Plus} onClick={openCreate}>Nueva Plantilla</Button>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {templates?.map(t => (
+          <Card key={t.id} hover>
+            <CardHeader className="flex justify-between items-center">
+              <CardTitle>{t.name}</CardTitle>
+              <div className="flex space-x-2">
+                <Button size="sm" variant="secondary" onClick={() => { setEditing(t); setForm(t); setShowModal(true); }}>Editar</Button>
+                <Button size="sm" variant="danger" onClick={() => deleteTemplate(t.id)}>Eliminar</Button>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="text-sm text-gray-600 mb-2">Estación: {stations?.find(s => s.id === t.stationId)?.name || t.stationId}</div>
+              <div className="border rounded p-2 text-center" style={{ backgroundColor: t.colors.background, color: t.colors.foreground }}>
+                {t.header}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <Modal isOpen={showModal} onClose={() => setShowModal(false)} title="Editar Plantilla" size="lg">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <Input label="Nombre" value={form.name || ''} onChange={e => setForm({ ...form, name: e.target.value })} />
+          <select className="border rounded-lg px-3 py-2" value={form.stationId || ''} onChange={e => setForm({ ...form, stationId: e.target.value })}>
+            <option value="">Estación</option>
+            {stations?.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
+          </select>
+          <Input label="Color de texto" type="color" value={form.colors?.foreground || '#000000'} onChange={e => setForm({ ...form, colors: { ...(form.colors || {}), foreground: e.target.value } })} />
+          <Input label="Color de fondo" type="color" value={form.colors?.background || '#ffffff'} onChange={e => setForm({ ...form, colors: { ...(form.colors || {}), background: e.target.value } })} />
+          <Input label="Encabezado" value={form.header || ''} onChange={e => setForm({ ...form, header: e.target.value })} />
+          <Input label="Pie" value={form.footer || ''} onChange={e => setForm({ ...form, footer: e.target.value })} />
+          <Textarea label="Instrucciones (ES)" value={form.instructions?.es || ''} onChange={e => setForm({ ...form, instructions: { ...(form.instructions || {}), es: e.target.value } })} rows={3} />
+          <Textarea label="Instrucciones (EN)" value={form.instructions?.en || ''} onChange={e => setForm({ ...form, instructions: { ...(form.instructions || {}), en: e.target.value } })} rows={3} />
+        </div>
+        <div className="mt-4">
+          <Preview />
+        </div>
+        <div className="mt-6 flex justify-end space-x-2">
+          <Button variant="secondary" onClick={() => setShowModal(false)}>Cancelar</Button>
+          <Button icon={Palette} onClick={saveTemplate}>Guardar</Button>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -1,0 +1,43 @@
+import React, { forwardRef } from 'react';
+import { DivideIcon as LucideIcon } from 'lucide-react';
+
+interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  label?: string;
+  error?: string;
+  hint?: string;
+  icon?: LucideIcon;
+  fullWidth?: boolean;
+}
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(({ label, error, hint, icon: Icon, fullWidth = true, className = '', id, ...props }, ref) => {
+  const inputId = id || `textarea-${Math.random().toString(36).substr(2, 9)}`;
+  const classes = [
+    'block w-full px-3 py-2 border rounded-lg text-sm transition-colors duration-200',
+    'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent',
+    'disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed',
+    error ? 'border-red-300 text-red-900 placeholder-red-300 focus:ring-red-500' : 'border-gray-300 text-gray-900 placeholder-gray-400',
+    className
+  ].filter(Boolean).join(' ');
+
+  return (
+    <div className={fullWidth ? 'w-full' : ''}>
+      {label && (
+        <label htmlFor={inputId} className="block text-sm font-medium text-gray-700 mb-1">
+          {label}
+        </label>
+      )}
+      <div className="relative">
+        {Icon && (
+          <div className="absolute inset-y-0 left-0 pl-3 flex items-start pt-2 pointer-events-none">
+            <Icon className="h-4 w-4 text-gray-400" />
+          </div>
+        )}
+        <textarea ref={ref} id={inputId} className={classes} {...props} />
+      </div>
+      {hint && !error && <p className="mt-1 text-xs text-gray-500">{hint}</p>}
+      {error && <p className="mt-1 text-xs text-red-600">{error}</p>}
+    </div>
+  );
+});
+
+Textarea.displayName = 'Textarea';

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useReducer, useEffect, ReactNode } from 'react';
 import { storageManager } from '../services/storageManager';
 import { syncEngine } from '../services/syncEngine';
+import { maintenanceAgent } from '../services/maintenanceAgent';
 import type { UserSession, AppMode, SyncStatus, Company } from '../types';
 
 // ==========================================
@@ -210,6 +211,8 @@ export function AppProvider({ children }: AppProviderProps) {
 
   useEffect(() => {
     initializeApp();
+    maintenanceAgent.start();
+    return () => maintenanceAgent.stop();
   }, []);
 
   const initializeApp = async () => {

--- a/src/hooks/useData.ts
+++ b/src/hooks/useData.ts
@@ -466,6 +466,18 @@ export function useLeaveRequests() {
   });
 }
 
+export function useQRTemplates() {
+  return useData({
+    key: 'wmapp_qr_templates',
+    defaultValue: [],
+    filterFn: (tpl, filter) => {
+      const searchLower = filter.search.toLowerCase();
+      return !filter.search || tpl.name.toLowerCase().includes(searchLower);
+    },
+    sortFn: (a, b) => a.name.localeCompare(b.name)
+  });
+}
+
 // ==========================================
 // UTILIDADES
 // ==========================================

--- a/src/services/maintenanceAgent.ts
+++ b/src/services/maintenanceAgent.ts
@@ -1,0 +1,103 @@
+import { storageManager } from './storageManager';
+import { STORAGE_KEYS, ClockIn } from '../types';
+
+interface MaintenanceLog {
+  timestamp: string;
+  message: string;
+}
+
+class MaintenanceAgent {
+  private dailyMs = 24 * 60 * 60 * 1000;
+  private intervalId: NodeJS.Timeout | null = null;
+
+  start() {
+    this.runTasks();
+    if (this.intervalId) clearInterval(this.intervalId);
+    this.intervalId = setInterval(() => this.runTasks(), this.dailyMs);
+  }
+
+  stop() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  private runTasks() {
+    const lastRun = storageManager.get<string>('wmapp_last_maintenance');
+    const today = new Date().toDateString();
+    if (lastRun && new Date(lastRun).toDateString() === today) return;
+
+    this.rotateOldClockIns();
+    this.compressLargeModels();
+    this.runHealthCheck();
+    this.removeObsoleteKeys();
+
+    storageManager.set('wmapp_last_maintenance', new Date().toISOString());
+  }
+
+  private rotateOldClockIns() {
+    const data = storageManager.get<ClockIn[]>(STORAGE_KEYS.CLOCKINS, []);
+    const limit = Date.now() - 90 * 24 * 60 * 60 * 1000;
+    const filtered = data.filter(c => new Date(c.timestamp).getTime() >= limit);
+    if (filtered.length !== data.length) {
+      storageManager.set(STORAGE_KEYS.CLOCKINS, filtered);
+      this.log(`Removed ${data.length - filtered.length} old clock-ins`);
+    }
+  }
+
+  private compressLargeModels() {
+    const info = storageManager.getStorageInfo();
+    info.items.forEach(item => {
+      if (item.size > 100 * 1024 && item.metadata && !item.metadata.compressed) {
+        const data = storageManager.get(item.key);
+        if (data) {
+          const success = storageManager.set(item.key, data, { compress: true });
+          if (success) {
+            this.log(`Compressed ${item.key}`);
+          }
+        }
+      }
+    });
+  }
+
+  private runHealthCheck() {
+    // Simple placeholder health check
+    const required = [STORAGE_KEYS.USERS, STORAGE_KEYS.COMPANIES, STORAGE_KEYS.STATIONS];
+    required.forEach(key => {
+      if (!storageManager.hasKey(key)) {
+        this.log(`HealthCheck warning: missing ${key}`);
+      }
+    });
+    this.log('HealthCheck complete');
+  }
+
+  private removeObsoleteKeys() {
+    const valid = new Set(Object.values(STORAGE_KEYS));
+    const toRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key) continue;
+      if (!valid.has(key) && !key.startsWith('backup_') && !key.startsWith('full_backup_')) {
+        toRemove.push(key);
+      }
+    }
+    toRemove.forEach(k => {
+      localStorage.removeItem(k);
+      this.log(`Removed obsolete key ${k}`);
+    });
+  }
+
+  private log(message: string) {
+    console.log('[Maintenance]', message);
+    const logs = storageManager.get<MaintenanceLog[]>('wmapp_maintenance_log', []);
+    logs.push({ timestamp: new Date().toISOString(), message });
+    storageManager.set('wmapp_maintenance_log', logs, { compress: false });
+  }
+
+  getLogs(): MaintenanceLog[] {
+    return storageManager.get<MaintenanceLog[]>('wmapp_maintenance_log', []) || [];
+  }
+}
+
+export const maintenanceAgent = new MaintenanceAgent();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -80,6 +80,21 @@ export interface Station extends BaseEntity {
   };
 }
 
+export interface QRTemplate extends BaseEntity {
+  name: string;
+  stationId: string;
+  companyId: string;
+  colors: {
+    foreground: string;
+    background: string;
+  };
+  logo?: string;
+  header: string;
+  footer: string;
+  instructions: Record<string, string>; // locale -> text
+  isDefault: boolean;
+}
+
 export interface ClockIn extends BaseEntity {
   userId: string;
   stationId: string;
@@ -279,6 +294,7 @@ export const STORAGE_KEYS = {
   APP_MODE: 'wmapp_mode',
   SYNC_QUEUE: 'wmapp_sync_queue',
   SETTINGS: 'wmapp_settings',
+  QR_TEMPLATES: 'wmapp_qr_templates',
 } as const;
 
 export const DEFAULT_PERMISSIONS: Record<User['role'], Permission[]> = {


### PR DESCRIPTION
## Summary
- add QR template type and storage key
- support QR templates via `useQRTemplates`
- create maintenance agent to rotate data and compress localStorage
- add textarea UI element
- add QR designer screen with preview and editing
- integrate maintenance agent and QR designer navigation

## Testing
- `npm run lint` *(fails: Cannot read properties of undefined)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6863e5d651708330af9d53fab16ecf71