### PR TITLE
Implement legalEngine for compliance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite-react-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "jspdf": "^2.5.1",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -288,6 +289,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1262,6 +1272,13 @@
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
       "dev": true
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "18.3.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
@@ -1622,6 +1639,18 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -1664,6 +1693,16 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -1731,6 +1770,18 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1768,6 +1819,26 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -1855,6 +1926,18 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/core-js": {
+      "version": "3.43.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.43.0.tgz",
+      "integrity": "sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1867,6 +1950,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -1921,6 +2014,13 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true
+    },
+    "node_modules/dompurify": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
+      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -2301,6 +2401,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2516,6 +2622,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2703,6 +2823,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.1.tgz",
+      "integrity": "sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.4.8"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.2.0",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/keyv": {
@@ -3031,6 +3169,13 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3248,6 +3393,16 @@
         }
       ]
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -3301,6 +3456,13 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -3335,6 +3497,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -3452,6 +3624,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
       }
     },
     "node_modules/string-width": {
@@ -3608,6 +3790,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
@@ -3643,6 +3835,16 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/text-table": {
@@ -3803,6 +4005,16 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.8",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "jspdf": "^2.5.1",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,9 @@ import { LeavesScreen } from './components/screens/LeavesScreen';
 import { ReportsScreen } from './components/screens/ReportsScreen';
 import { NotificationsScreen } from './components/screens/NotificationsScreen';
 import { SettingsScreen } from './components/screens/SettingsScreen';
+import { LegalInfoScreen } from './components/screens/LegalInfoScreen';
+import { LegalConsentModal } from './components/ui/LegalConsentModal';
+import { getConsent, isConsentExpired } from './services/legalEngine';
 
 // ==========================================
 // COMPONENTE PRINCIPAL DE LA APLICACIÓN
@@ -17,6 +20,16 @@ import { SettingsScreen } from './components/screens/SettingsScreen';
 
 function AppContent() {
   const { state } = useApp();
+  const [showConsent, setShowConsent] = React.useState(false);
+
+  React.useEffect(() => {
+    if (state.isAuthenticated) {
+      const consent = getConsent(state.session!.user.id);
+      if (!consent || isConsentExpired(consent)) {
+        setShowConsent(true);
+      }
+    }
+  }, [state.isAuthenticated, state.session]);
 
   // Mostrar loading durante inicialización
   if (state.loading && !state.isAuthenticated) {
@@ -53,6 +66,8 @@ function AppContent() {
         return <ReportsScreen />;
       case 'settings':
         return <SettingsScreen />;
+      case 'legal':
+        return <LegalInfoScreen />;
       case 'notifications':
         return <NotificationsScreen />;
       default:
@@ -62,6 +77,9 @@ function AppContent() {
 
   return (
     <div className="min-h-screen bg-gray-50">
+      {showConsent && state.session && (
+        <LegalConsentModal workerId={state.session.user.id} onAccepted={() => setShowConsent(false)} />
+      )}
       {/* Banner de modo de aplicación */}
       {state.appMode.ui.showModeBanner && (
         <div className={`w-full py-2 px-4 text-center text-sm font-medium ${getModeColors(state.appMode.mode)}`}>

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -5,8 +5,9 @@ import {
   Users, 
   MapPin, 
   Calendar, 
-  BarChart3, 
-  Settings, 
+  BarChart3,
+  Shield,
+  Settings,
   LogOut,
   Bell,
   Menu,
@@ -31,6 +32,7 @@ export function MainLayout({ children }: MainLayoutProps) {
     { name: 'Estaciones', icon: MapPin, screen: 'stations', roles: ['admin', 'manager'] },
     { name: 'Ausencias', icon: Calendar, screen: 'leaves', roles: ['admin', 'manager', 'employee'] },
     { name: 'Reportes', icon: BarChart3, screen: 'reports', roles: ['admin', 'manager'] },
+    { name: 'Legal', icon: Shield, screen: 'legal', roles: ['admin', 'manager', 'employee'] },
     { name: 'Configuración', icon: Settings, screen: 'settings', roles: ['admin', 'manager', 'employee'] },
   ];
 

--- a/src/components/screens/LegalInfoScreen.tsx
+++ b/src/components/screens/LegalInfoScreen.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/Card';
+import { legalTexts, getPreferredLanguage } from '../../services/legalEngine';
+import { Button } from '../ui/Button';
+import { useApp } from '../../contexts/AppContext';
+
+export function LegalInfoScreen() {
+  const lang = getPreferredLanguage();
+  const { navigateTo } = useApp();
+  const text = legalTexts[lang];
+
+  return (
+    <div className="p-4 space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Política de Privacidad</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ul className="list-disc pl-5 space-y-2 text-sm">
+            {text.privacy.map((p, idx) => (
+              <li key={idx}>{p}</li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>¿Esto es legal en mi país?</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm mb-2">{text.aid}</p>
+          <p className="text-xs text-gray-600">{text.disclaimer}</p>
+        </CardContent>
+      </Card>
+      <Button onClick={() => navigateTo('settings')}>Volver</Button>
+    </div>
+  );
+}

--- a/src/components/ui/LegalConsentModal.tsx
+++ b/src/components/ui/LegalConsentModal.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Modal } from './Modal';
+import { Button } from './Button';
+import { legalTexts, saveConsent, getPreferredLanguage } from '../../services/legalEngine';
+import { useApp } from '../../contexts/AppContext';
+
+interface Props {
+  workerId: string;
+  onAccepted: () => void;
+}
+
+export function LegalConsentModal({ workerId, onAccepted }: Props) {
+  const lang = getPreferredLanguage();
+  const text = legalTexts[lang];
+
+  const handleAccept = () => {
+    saveConsent({
+      workerId,
+      acceptedAt: new Date().toISOString(),
+      language: lang,
+      consentText: text.consent
+    });
+    onAccepted();
+  };
+
+  return (
+    <Modal isOpen={true} onClose={() => {}} title="Legal" hideClose>
+      <p className="mb-4 text-sm whitespace-pre-line">{text.consent}</p>
+      <Button onClick={handleAccept} className="w-full mt-2">
+        Aceptar
+      </Button>
+    </Modal>
+  );
+}

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useReducer, useEffect, ReactNode } from 'react';
 import { storageManager } from '../services/storageManager';
 import { syncEngine } from '../services/syncEngine';
+import { startLegalPurge } from '../services/legalEngine';
 import type { UserSession, AppMode, SyncStatus, Company } from '../types';
 
 // ==========================================
@@ -238,6 +239,8 @@ export function AppProvider({ children }: AppProviderProps) {
       // Cargar estado de sincronización
       const syncStatus = syncEngine.getStatus();
       dispatch({ type: 'SET_SYNC_STATUS', payload: syncStatus });
+
+      startLegalPurge();
 
       console.log('[AppProvider] App initialized successfully');
 

--- a/src/services/legalEngine.ts
+++ b/src/services/legalEngine.ts
@@ -1,0 +1,165 @@
+export interface LegalConsent {
+  workerId: string;
+  acceptedAt: string; // ISO 8601
+  language: string;
+  consentText: string;
+}
+
+export interface LegalReportEntry {
+  date: string;
+  type: string;
+  stationId: string;
+  stationLocation?: string;
+}
+
+export interface LegalReport {
+  employeeName: string;
+  entries: LegalReportEntry[];
+  qrStationIds: string[];
+  signature?: string;
+  deviceHash: string;
+  appVersion: string;
+}
+
+import { storageManager } from './storageManager';
+import { jsPDF } from 'jspdf';
+import { APP_CONFIG } from '../types';
+
+const CONSENT_KEY = 'wmapp_legal_consents';
+
+export const legalTexts: Record<string, { consent: string; privacy: string[]; disclaimer: string; aid: string }> = {
+  es: {
+    consent:
+      'La empresa garantizar\u00E1 el registro diario de jornada, incluyendo el horario concreto de inicio y finalizaci\u00F3n de la jornada de trabajo de cada persona trabajadora. — Art\u00EDculo 34.9, Estatuto de los Trabajadores (Espa\u00F1a)',
+    privacy: [
+      'No se recogen datos biom\u00E9tricos.',
+      'No se env\u00EDan datos a servidores externos.',
+      'Los datos se guardan exclusivamente en el dispositivo del usuario.',
+      'La aplicaci\u00F3n es responsable de la herramienta, no del uso administrativo o legal final.'
+    ],
+    disclaimer: 'Esta herramienta no sustituye la asesor\u00EDa legal. Su uso debe revisarse conforme a la legislaci\u00F3n de tu pa\u00EDs.',
+    aid: 'Comparativa entre legislaci\u00F3n espa\u00F1ola y la local (si existe).' 
+  },
+  en: {
+    consent:
+      'The company will guarantee the daily record of working hours, including the specific start and end times of each worker\'s day. — Article 34.9, Workers\' Statute (Spain)',
+    privacy: [
+      'No biometric data is collected.',
+      'No data is sent to external servers.',
+      'Data is stored exclusively on the user\'s device.',
+      'The application is responsible for the tool, not for final administrative or legal use.'
+    ],
+    disclaimer: 'This tool does not replace legal advice. Its use must be reviewed according to your country\'s legislation.',
+    aid: 'Comparison between Spanish legislation and local law (if available).' 
+  },
+  bn: {
+    consent:
+      '\u0985\u09B0\u09CD\u09A5\u09C7 \u0995\u09CD\u09B0\u09AE\u09BF \u09AA\u09CD\u09B0\u09A4\u09BF\u09A6\u09BF\u09A8 \u09B0\u09CB\u099C\u09BE\u09B0 \u09A8\u09BF\u09A6\u09B0\u09CD\u09B6 \u09B0\u09C7\u0995\u09B0\u09CD\u09A1 \u0989\u09A6\u09CD\u09AF\u09CB\u0997 \u0995\u09B0\u09AC\u09C7, \u09AA\u09CD\u09B0\u09A4\u09CD\u09AF\u0995\u09CD\u09B7 \u0986\u09B0\u09AE\u09CD\u09AD \u0986\u09B0\u09AE\u09CD\u09AD \u09B8\u09AE\u09DF \u0986\u09B0\u09AE\u09CD\u09AD \u09B8\u09B9\u0995\u09BE\u09B2\u09C7 \u09B6\u09C1\u09B0\u09C1 \u09A8\u09BF\u09B6\u09CD\u099A\u09BF\u09A4 \u0995\u09B0\u09A4\u09C7 \u09AB\u09B0\u09AE\u09BE\u09A8 \u09B0\u09C7\u0995\u09B0\u09CD\u09A1 \u0995\u09B0\u09BE \u09B9\u09AC\u09C7। — \u09A8\u09BF\u09AF\u09BC\u09AE 34.9, \u09B8\u09CD\u0995\u09B0\u09CD\u09AE\u09B8\u09A8\u09CD\u09A4 \u0985\u09AB \u09A6\u09BE \u09A4\u09CD\u09B0\u09BE\u09AC\u09BE\u09A6\u09C7\u09B0\u09B8 (\u09B8\u09CD\u09AA\u09C7\u0987\u09A8)',
+    privacy: [
+      '\u0995\u09CB\u09A8 \u09AC\u09BE\u09AF\u09CB\u09AE\u09C7\u099F\u09CD\u09B0\u09BF\u0995 \u09A1\u09C7\u099F\u09BE \u09B8\u0999\u09CD\u0995\u09B2\u09A8\u09BE \u09B9\u09DF\u09A8।',
+      '\u0995\u09CB\u09A8 \u09A1\u09C7\u099F\u09BE \u09AC\u09BE\u09B9\u09BF\u09B0 \u09B8\u09BE\u09B0\u09CD\u09AD\u09BE\u09B0\u09C7 \u09AA\u09BE\u09A0\u09BE\u09A8\u09CB \u09B9\u09DF\u09A8।',
+      '\u09A1\u09C7\u099F\u09BE \u0985\u09AA\u09A8\u09BE\u09B0 \u09AA\u09CD\u09B0\u09A4\u09BF\u09B7\u09CD\u09A0\u09BE\u09A8 \u09AA\u09C7 \u09B0\u09BE\u0996\u09BE \u09B9\u09DF\u09A8।',
+      '\u098F\u09AA\u09CD\u09B2\u09BF\u0995\u09C7\u09B6\u09A8 \u09B8\u09B0\u09A8\u09BE\u09AE \u09AE\u09C1\u0995\u099F\u09BF \u09AA\u09CD\u09B0\u09A4\u09BF\u09B7\u09CD\u09A0\u09BE \u09AF\u09A8\u09BE \u0995\u09B0\u09C7, \u09B6\u09C7\u09B7 \u09AA\u09CD\u09B0\u09B6\u09BE\u09B8\u09A8\u09C7 \u09A8\u09C7।'
+    ],
+    disclaimer: 'এই টুল কোনও আইনি পরামর্শের বিকল্প নয়। আপনার দেশের আইন অনুসারে এর ব্যবহার পর্যালোচনা করা উচিত।',
+    aid: 'স্পেনের আইন ও স্থানীয় আইনের তুলনা (যদি থাকে)।'
+  },
+  'zh-TW': {
+    consent:
+      '\u516C\u53F8\u5C07\u4FDD\u8B49\u65E5\u5E38\u8A18\u9304\u5DE5\u4F5C\u6642\u6578\uFF0C\u5305\u62EC\u6BCF\u500B\u52DE\u5DE5\u5DE5\u4F5C\u65E5\u7684\u958B\u59CB\u548C\u7D42\u6B62\u6642\u9593\u3002\u2014\u897F\u73ED\u7259\u52DE\u5DE5\u6CD5\u7AE0 34.9',
+    privacy: [
+      '\u4E0D\u6536\u96C6\u751F\u7269\u8CC7\u6599\u3002',
+      '\u4E0D\u5C07\u8CC7\u6599\u50B3\u9001\u5230\u5916\u90E8\u4F3A\u670D\u5668\u3002',
+      '\u8CC7\u6599\u50C5\u4FDD\u5B58\u5728\u7528\u6236\u8A2D\u5099\u4E2D\u3002',
+      '\u61C9\u7528\u7A0B\u5F0F\u53EA\u5C0D\u5DE5\u5177\u672C\u8EAB\u8CA0\u8CAC\uFF0C\u4E0D\u5C0D\u884C\u653F\u6216\u6CD5\u5F8B\u4F7F\u7528\u627F\u64D4\u8CAC\u4EFB\u3002'
+    ],
+    disclaimer: '\u9019\u500B\u5DE5\u5177\u4E0D\u53EF\u53D6\u4EE3\u6CD5\u5F8B\u5C0E\u5E2B\u3002\u4F7F\u7528\u524D\u61C9\u6AA2\u8996\u5404\u56FD\u6CD5\u5F8B\u3002',
+    aid: '\u897F\u73ED\u7259\u6CD5\u4F8B\u8207\u7576\u5730\u6CD5\u898F\u6BD4\u8F03\uFF08\u5982\u6709\uFF09\u3002'
+  },
+  ar: {
+    consent:
+      '\u062A\u0644\u062A\u0632\u0645 \u0627\u0644\u0634\u0631\u0643\u0629 \u0628\u062A\u0633\u062C\u064A\u0644 \u064A\u0648\u0645\u064A \u0644\u0644\u0633\u0627\u0639\u0627\u062A \u0645\u062A\u0636\u0645\u0646\u0627 \u0648\u0642\u062A \u0628\u062F\u0621 \u0648\u0627\u0646\u062A\u0647\u0627\u0621 \u0643\u0644 \u0639\u0627\u0645\u0644. — \u0627\u0644\u0645\u0627\u062F\u0629 34.9 \u0645\u0646 \u0642\u0627\u0646\u0648\u0646 \u0627\u0644\u0639\u0645\u0644 \u0627\u0644\u0625\u0633\u0628\u0627\u0646\u064A',
+    privacy: [
+      '\u0644\u0627 \u062A\u064F\u062C\u0645\u064E\u0639 \u0628\u064A\u0627\u0646\u0627\u062A \u062D\u064A\u0648\u064A\u0629.',
+      '\u0644\u0627 \u064A\u064F\u0631\u0633\u064E\u0644 \u0623\u064A \u0628\u064A\u0627\u0646\u0627\u062A \u0625\u0644\u0649 \u062E\u0648\u0627\u062F\u0645 \u062E\u0627\u0631\u062C\u064A\u0629.',
+      '\u062A\u064F\u062D\u0641\u064E\u0638 \u0627\u0644\u0628\u064A\u0627\u0646\u0627\u062A \u062D\u0635\u0631\u0627\u064B \u0641\u064A \u062C\u0647\u0627\u0632 \u0627\u0644\u0645\u0633\u062A\u062E\u062F\u0645.',
+      '\u0627\u0644\u062A\u0637\u0628\u064A\u0642 \u0645\u0633\u0624\u0648\u0644 \u0639\u0646 \u0627\u0644\u0623\u062F\u0627\u0629 \u0641\u0642\u0637 \u0648\u0644\u064A\u0633 \u0639\u0646 \u0627\u0644\u0627\u0633\u062A\u062E\u062F\u0627\u0645 \u0627\u0644\u0625\u062F\u0627\u0631\u064A \u0623\u0648 \u0627\u0644\u0642\u0627\u0646\u0648\u0646\u064A \u0627\u0644\u0646\u0647\u0627\u0626\u064A.'
+    ],
+    disclaimer: '\u0647\u0630\u0647 \u0627\u0644\u0623\u062F\u0627\u0629 \u0644\u0627 \u062A\u063A\u0646\u064A \u0639\u0646 \u0627\u0644\u0645\u0634\u0648\u0631\u0629 \u0627\u0644\u0642\u0627\u0646\u0648\u0646\u064A\u0629. \u064A\u062C\u0628 \u0641\u062D\u0635 \u0627\u0633\u062A\u062E\u062F\u0627\u0645\u0647\u0627 \u062D\u0633\u0628 \u0642\u0648\u0627\u0646\u064A\u0646 \u0628\u0644\u062F\u0643.',
+    aid: '\u0645\u0642\u0627\u0631\u0646\u0629 \u0628\u064A\u0646 \u0627\u0644\u062A\u0634\u0631\u064A\u0639 \u0627\u0644\u0625\u0633\u0628\u0627\u0646\u064A \u0648\u0627\u0644\u0642\u0627\u0646\u0648\u0646 \u0627\u0644\u0645\u062D\u0644\u064A (\u0625\u0630\u0627 \u0648\u062C\u062F).'
+  },
+  fr: {
+    consent:
+      "L'entreprise garantira l'enregistrement quotidien de la journ\u00E9e de travail, y compris l'heure de d\u00E9but et de fin de chaque journ\u00E9e de travail. — Article 34.9, Statut des Travailleurs (Espagne)",
+    privacy: [
+      "Aucune donn\u00E9e biom\u00E9trique n'est collect\u00E9e.",
+      "Aucune donn\u00E9e n'est envoy\u00E9e \u00E0 des serveurs externes.",
+      "Les donn\u00E9es sont stock\u00E9es exclusivement sur l'appareil de l'utilisateur.",
+      "L'application est responsable de l'outil et non de l'utilisation administrative ou l\u00E9gale finale."
+    ],
+    disclaimer: "Cet outil ne remplace pas les conseils juridiques. Son utilisation doit \u00EAtre revue conform\u00E9ment \u00E0 la l\u00E9gislation de votre pays.",
+    aid: "Comparaison entre la l\u00E9gislation espagnole et la l\u00E9gislation locale (si disponible)."
+  }
+};
+
+export function getPreferredLanguage(): string {
+  const lang = navigator.language.split('-')[0];
+  if (legalTexts[lang]) return lang;
+  return 'es';
+}
+
+export function saveConsent(consent: LegalConsent): void {
+  const consents = storageManager.get<LegalConsent[]>(CONSENT_KEY, []);
+  const filtered = consents.filter(c => c.workerId !== consent.workerId);
+  storageManager.set(CONSENT_KEY, [...filtered, consent]);
+}
+
+export function getConsent(workerId: string): LegalConsent | undefined {
+  const consents = storageManager.get<LegalConsent[]>(CONSENT_KEY, []);
+  return consents.find(c => c.workerId === workerId);
+}
+
+export function isConsentExpired(consent: LegalConsent): boolean {
+  const accepted = new Date(consent.acceptedAt).getTime();
+  const now = Date.now();
+  return now - accepted > 365 * 24 * 60 * 60 * 1000; // 12 months
+}
+
+export async function generateLegalReport(report: LegalReport): Promise<{ pdf: Blob; json: Blob }> {
+  const doc = new jsPDF();
+  doc.text('Informe de Registro de Jornada', 10, 10);
+  doc.text('Empleado: ' + report.employeeName, 10, 20);
+  doc.text('Dispositivo: ' + report.deviceHash, 10, 30);
+  doc.text('Versi\u00F3n: ' + report.appVersion, 10, 40);
+  doc.text('---', 10, 50);
+  let y = 60;
+  report.entries.forEach(e => {
+    doc.text(`${e.date} - ${e.type} - ${e.stationId}`, 10, y);
+    y += 10;
+  });
+  doc.text('Este informe es compatible con el modelo exigido por el Ministerio de Trabajo seg\u00FAn el art\u00EDculo 34.9 del Estatuto de los Trabajadores (Espa\u00F1a).', 10, y + 10);
+
+  const pdfBlob = doc.output('blob');
+  const jsonBlob = new Blob([JSON.stringify(report, null, 2)], { type: 'application/json' });
+  return { pdf: pdfBlob, json: jsonBlob };
+}
+
+export function startLegalPurge() {
+  setInterval(() => {
+    purgeConsents();
+    purgeClockIns();
+  }, 24 * 60 * 60 * 1000);
+}
+
+function purgeConsents() {
+  const consents = storageManager.get<LegalConsent[]>(CONSENT_KEY, []);
+  const valid = consents.filter(c => !isConsentExpired(c));
+  storageManager.set(CONSENT_KEY, valid);
+}
+
+function purgeClockIns() {
+  const clockins = storageManager.get<any[]>('wmapp_clockins', []);
+  const threshold = Date.now() - 90 * 24 * 60 * 60 * 1000;
+  const filtered = clockins.filter(c => new Date(c.timestamp).getTime() > threshold || c.exported);
+  storageManager.set('wmapp_clockins', filtered);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -298,3 +298,29 @@ export const DEFAULT_PERMISSIONS: Record<User['role'], Permission[]> = {
     { resource: 'profile', actions: ['read', 'update'] }
   ]
 };
+// ==========================================
+// LEGAL TYPES
+// ==========================================
+
+export interface LegalConsent {
+  workerId: string;
+  acceptedAt: string; // ISO 8601
+  language: string;
+  consentText: string;
+}
+
+export interface LegalReportEntry {
+  date: string;
+  type: string;
+  stationId: string;
+  stationLocation?: string;
+}
+
+export interface LegalReport {
+  employeeName: string;
+  entries: LegalReportEntry[];
+  qrStationIds: string[];
+  signature?: string;
+  deviceHash: string;
+  appVersion: string;
+}


### PR DESCRIPTION
## Summary
- add `jspdf` dependency
- create `legalEngine` service with consent storage, privacy policy texts, report generation and purge logic
- implement `LegalConsentModal` and `LegalInfoScreen`
- integrate legal screens and purge engine into app context
- add Legal menu item

## Testing
- `npm run lint` *(fails: 85 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6863ead1b4a48330b63d771a7be0802d