### PR TITLE
Add dark mode and privacy tools

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import { LeavesScreen } from './components/screens/LeavesScreen';
 import { ReportsScreen } from './components/screens/ReportsScreen';
 import { NotificationsScreen } from './components/screens/NotificationsScreen';
 import { SettingsScreen } from './components/screens/SettingsScreen';
+import { PrivacyDialog } from './components/ui/PrivacyDialog';
+import { legalService } from './services/legalService';
 
 // ==========================================
 // COMPONENTE PRINCIPAL DE LA APLICACIÓN
@@ -17,6 +19,16 @@ import { SettingsScreen } from './components/screens/SettingsScreen';
 
 function AppContent() {
   const { state } = useApp();
+  const [showConsent, setShowConsent] = React.useState(false);
+
+  React.useEffect(() => {
+    if (state.isAuthenticated && state.session) {
+      const consent = legalService.getConsent(state.session.user.id);
+      if (!consent) {
+        setShowConsent(true);
+      }
+    }
+  }, [state.isAuthenticated, state.session]);
 
   // Mostrar loading durante inicialización
   if (state.loading && !state.isAuthenticated) {
@@ -60,8 +72,15 @@ function AppContent() {
     }
   };
 
+  const handleAcceptConsent = () => {
+    if (state.session) {
+      legalService.saveConsent(state.session.user.id, navigator.language);
+    }
+    setShowConsent(false);
+  };
+
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
       {/* Banner de modo de aplicación */}
       {state.appMode.ui.showModeBanner && (
         <div className={`w-full py-2 px-4 text-center text-sm font-medium ${getModeColors(state.appMode.mode)}`}>
@@ -73,18 +92,20 @@ function AppContent() {
         {renderCurrentScreen()}
       </MainLayout>
 
+      <PrivacyDialog isOpen={showConsent} onAccept={handleAcceptConsent} />
+
       {/* Notificaciones Toast */}
       {state.notifications.length > 0 && (
         <div className="fixed top-4 right-4 z-50 space-y-2">
           {state.notifications.slice(0, 3).map((notification) => (
             <div
               key={notification.id}
-              className={`max-w-sm bg-white rounded-lg shadow-lg p-4 border-l-4 ${getNotificationColors(notification.type)}`}
+              className={`max-w-sm bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4 border-l-4 ${getNotificationColors(notification.type)}`}
             >
               <div className="flex items-start">
                 <div className="flex-1">
-                  <h4 className="text-sm font-semibold text-gray-900">{notification.title}</h4>
-                  <p className="text-sm text-gray-600 mt-1">{notification.message}</p>
+                  <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100">{notification.title}</h4>
+                  <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">{notification.message}</p>
                 </div>
                 <button
                   onClick={() => {/* clearNotification(notification.id) */}}

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -6,15 +6,18 @@ import {
   MapPin, 
   Calendar, 
   BarChart3, 
-  Settings, 
+  Settings,
   LogOut,
   Bell,
   Menu,
-  X
+  X,
+  Sun,
+  Moon
 } from 'lucide-react';
 import { Button } from '../ui/Button';
 import { Badge } from '../ui/Badge';
 import { useApp } from '../../contexts/AppContext';
+import { useTheme } from '../../hooks/useTheme';
 
 interface MainLayoutProps {
   children: React.ReactNode;
@@ -23,6 +26,7 @@ interface MainLayoutProps {
 export function MainLayout({ children }: MainLayoutProps) {
   const { state, logout, navigateTo, clearAllNotifications } = useApp();
   const [sidebarOpen, setSidebarOpen] = React.useState(false);
+  const { theme, toggleTheme } = useTheme();
 
   const navigation = [
     { name: 'Dashboard', icon: Home, screen: 'dashboard', roles: ['admin', 'manager', 'employee'] },
@@ -44,7 +48,7 @@ export function MainLayout({ children }: MainLayoutProps) {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 flex">
       {/* Mobile sidebar overlay */}
       {sidebarOpen && (
         <div 
@@ -55,18 +59,18 @@ export function MainLayout({ children }: MainLayoutProps) {
 
       {/* Sidebar - Fixed positioning */}
       <div className={`
-        fixed inset-y-0 left-0 z-50 w-64 bg-white shadow-lg transform transition-transform duration-300 ease-in-out
+        fixed inset-y-0 left-0 z-50 w-64 bg-white dark:bg-gray-800 shadow-lg transform transition-transform duration-300 ease-in-out
         lg:translate-x-0 lg:static lg:inset-0 lg:z-auto
         ${sidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}
       `}>
         <div className="flex flex-col h-full">
           {/* Logo */}
-          <div className="flex items-center justify-between h-16 px-6 border-b border-gray-200 bg-white">
+          <div className="flex items-center justify-between h-16 px-6 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
             <div className="flex items-center space-x-3">
               <div className="bg-blue-600 rounded-lg p-2">
                 <Home className="w-6 h-6 text-white" />
               </div>
-              <span className="text-lg font-semibold text-gray-900">WM System</span>
+              <span className="text-lg font-semibold text-gray-900 dark:text-gray-100">WM System</span>
             </div>
             <Button
               variant="ghost"
@@ -87,9 +91,9 @@ export function MainLayout({ children }: MainLayoutProps) {
                   onClick={() => handleNavigation(item.screen)}
                   className={`
                     w-full flex items-center px-3 py-2.5 text-sm font-medium rounded-lg transition-all duration-200
-                    ${isActive 
-                      ? 'bg-blue-50 text-blue-700 border-r-2 border-blue-600 shadow-sm' 
-                      : 'text-gray-700 hover:bg-gray-50 hover:text-gray-900'
+                    ${isActive
+                      ? 'bg-blue-50 dark:bg-gray-700 text-blue-700 dark:text-white border-r-2 border-blue-600 shadow-sm'
+                      : 'text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white'
                     }
                   `}
                 >
@@ -101,7 +105,7 @@ export function MainLayout({ children }: MainLayoutProps) {
           </nav>
 
           {/* User info */}
-          <div className="border-t border-gray-200 p-4 bg-gray-50">
+          <div className="border-t border-gray-200 dark:border-gray-700 p-4 bg-gray-50 dark:bg-gray-800">
             <div className="flex items-center space-x-3 mb-3">
               <div className="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center">
                 <span className="text-sm font-medium text-blue-600">
@@ -109,10 +113,10 @@ export function MainLayout({ children }: MainLayoutProps) {
                 </span>
               </div>
               <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-gray-900 truncate">
+                <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
                   {state.session?.user.firstName} {state.session?.user.lastName}
                 </p>
-                <p className="text-xs text-gray-500 capitalize">
+                <p className="text-xs text-gray-500 dark:text-gray-400 capitalize">
                   {state.session?.user.role}
                 </p>
               </div>
@@ -123,7 +127,7 @@ export function MainLayout({ children }: MainLayoutProps) {
               icon={LogOut}
               onClick={logout}
               fullWidth
-              className="text-gray-600 hover:text-red-600 hover:bg-red-50"
+              className="text-gray-600 dark:text-gray-300 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-800"
             >
               Cerrar Sesión
             </Button>
@@ -134,7 +138,7 @@ export function MainLayout({ children }: MainLayoutProps) {
       {/* Main content area */}
       <div className="flex-1 flex flex-col min-h-screen lg:ml-0">
         {/* Top bar */}
-        <header className="bg-white shadow-sm border-b border-gray-200 sticky top-0 z-30">
+        <header className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700 sticky top-0 z-30">
           <div className="flex items-center justify-between h-16 px-4 sm:px-6">
             <div className="flex items-center space-x-4">
               <Button
@@ -145,7 +149,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                 className="lg:hidden"
               />
               <div>
-                <h1 className="text-xl font-semibold text-gray-900">
+                <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
                   {state.currentCompany?.name || 'Workforce Management'}
                 </h1>
                 {state.appMode.mode === 'demo' && (
@@ -158,7 +162,7 @@ export function MainLayout({ children }: MainLayoutProps) {
               {/* Online/Offline indicator */}
               <div className="flex items-center space-x-2">
                 <div className={`w-2 h-2 rounded-full ${state.isOnline ? 'bg-green-500' : 'bg-red-500'}`} />
-                <span className="text-sm text-gray-600 hidden sm:inline">
+                <span className="text-sm text-gray-600 dark:text-gray-300 hidden sm:inline">
                   {state.isOnline ? 'En línea' : 'Sin conexión'}
                 </span>
               </div>
@@ -167,11 +171,18 @@ export function MainLayout({ children }: MainLayoutProps) {
               {state.syncStatus.pendingCount > 0 && (
                 <div className="flex items-center space-x-2 text-amber-600">
                   <div className="animate-pulse w-2 h-2 bg-amber-500 rounded-full" />
-                  <span className="text-sm hidden sm:inline">
+                  <span className="text-sm hidden sm:inline dark:text-amber-400">
                     {state.syncStatus.pendingCount} pendiente{state.syncStatus.pendingCount !== 1 ? 's' : ''}
                   </span>
                 </div>
               )}
+
+              <Button
+                variant="ghost"
+                size="sm"
+                icon={theme === 'dark' ? Sun : Moon}
+                onClick={toggleTheme}
+              />
 
               {/* Notifications */}
               <div className="relative">
@@ -197,7 +208,7 @@ export function MainLayout({ children }: MainLayoutProps) {
         </header>
 
         {/* Page content */}
-        <main className="flex-1 overflow-auto">
+        <main className="flex-1 overflow-auto bg-white dark:bg-gray-900">
           <div className="h-full">
             {children}
           </div>

--- a/src/components/screens/SettingsScreen.tsx
+++ b/src/components/screens/SettingsScreen.tsx
@@ -24,6 +24,7 @@ import { Modal } from '../ui/Modal';
 import { useApp } from '../../contexts/AppContext';
 import { storageManager } from '../../services/storageManager';
 import { environmentInitializer } from '../../services/initializeDefaultEnvironment';
+import { legalService } from '../../services/legalService';
 
 export function SettingsScreen() {
   const { state, showNotification, switchAppMode } = useApp();
@@ -31,6 +32,7 @@ export function SettingsScreen() {
   const [showResetModal, setShowResetModal] = useState(false);
   const [showExportModal, setShowExportModal] = useState(false);
   const [showPasswordModal, setShowPasswordModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
   
   const [profileData, setProfileData] = useState({
     firstName: state.session?.user.firstName || '',
@@ -101,7 +103,7 @@ export function SettingsScreen() {
 
   const handleExportData = (format: 'json' | 'csv') => {
     try {
-      const data = storageManager.exportData();
+      const data = legalService.downloadUserData(state.session!.user.id);
       
       const blob = new Blob([data], { 
         type: format === 'json' ? 'application/json' : 'text/csv' 
@@ -193,6 +195,20 @@ export function SettingsScreen() {
       autoClose: true
     });
     setShowPasswordModal(false);
+  };
+
+  const handleDeleteAccount = () => {
+    if (state.session) {
+      legalService.deleteAccount(state.session.user.id);
+    }
+    showNotification({
+      type: 'success',
+      title: 'Cuenta eliminada',
+      message: 'Tus datos locales se han borrado',
+      autoClose: true
+    });
+    setShowDeleteModal(false);
+    setTimeout(() => window.location.reload(), 1000);
   };
 
   // ==========================================
@@ -518,6 +534,29 @@ export function SettingsScreen() {
               </Button>
             </CardContent>
           </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center space-x-2">
+                <Trash2 className="w-5 h-5" />
+                <span>Borrar Cuenta</span>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <p className="text-gray-600">
+                Elimina tu cuenta y borra todos los datos locales asociados.
+              </p>
+
+              <Button
+                onClick={() => setShowDeleteModal(true)}
+                variant="danger"
+                icon={Trash2}
+                fullWidth
+              >
+                Borrar Mi Cuenta
+              </Button>
+            </CardContent>
+          </Card>
         </div>
       </div>
       
@@ -741,6 +780,27 @@ export function SettingsScreen() {
               icon={Shield}
             >
               Entendido
+            </Button>
+          </div>
+        </div>
+      </Modal>
+
+      <Modal
+        isOpen={showDeleteModal}
+        onClose={() => setShowDeleteModal(false)}
+        title="Eliminar Cuenta"
+        size="md"
+      >
+        <div className="space-y-4">
+          <p className="text-gray-600">
+            ¿Seguro que deseas eliminar tu cuenta y todos los datos locales?
+          </p>
+          <div className="flex justify-end space-x-3">
+            <Button onClick={() => setShowDeleteModal(false)} variant="secondary">
+              Cancelar
+            </Button>
+            <Button onClick={handleDeleteAccount} variant="danger" icon={Trash2}>
+              Borrar
             </Button>
           </div>
         </div>

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -21,7 +21,7 @@ export function Card({
   };
 
   const classes = [
-    'bg-white rounded-lg shadow-sm border border-gray-200',
+    'bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700',
     paddingClasses[padding],
     hover ? 'hover:shadow-md transition-shadow duration-200' : '',
     className
@@ -41,7 +41,7 @@ interface CardHeaderProps {
 
 export function CardHeader({ children, className = '' }: CardHeaderProps) {
   return (
-    <div className={`border-b border-gray-200 pb-4 mb-4 ${className}`}>
+    <div className={`border-b border-gray-200 dark:border-gray-700 pb-4 mb-4 ${className}`}>
       {children}
     </div>
   );
@@ -54,7 +54,7 @@ interface CardTitleProps {
 
 export function CardTitle({ children, className = '' }: CardTitleProps) {
   return (
-    <h3 className={`text-lg font-semibold text-gray-900 ${className}`}>
+    <h3 className={`text-lg font-semibold text-gray-900 dark:text-gray-100 ${className}`}>
       {children}
     </h3>
   );

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -24,12 +24,12 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({
   const inputId = id || `input-${Math.random().toString(36).substr(2, 9)}`;
 
   const inputClasses = [
-    'block px-3 py-2 border rounded-lg text-sm transition-colors duration-200',
+    'block px-3 py-2 border rounded-lg text-sm transition-colors duration-200 bg-white dark:bg-gray-700',
     'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent',
     'disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed',
     error 
-      ? 'border-red-300 text-red-900 placeholder-red-300 focus:ring-red-500' 
-      : 'border-gray-300 text-gray-900 placeholder-gray-400',
+      ? 'border-red-300 text-red-900 placeholder-red-300 focus:ring-red-500 dark:border-red-600'
+      : 'border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-400',
     Icon && iconPosition === 'left' ? 'pl-10' : '',
     Icon && iconPosition === 'right' ? 'pr-10' : '',
     fullWidth ? 'w-full' : '',
@@ -39,7 +39,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({
   return (
     <div className={fullWidth ? 'w-full' : ''}>
       {label && (
-        <label htmlFor={inputId} className="block text-sm font-medium text-gray-700 mb-1">
+        <label htmlFor={inputId} className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
           {label}
         </label>
       )}
@@ -66,7 +66,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({
       </div>
       
       {hint && !error && (
-        <p className="mt-1 text-xs text-gray-500">{hint}</p>
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{hint}</p>
       )}
       
       {error && (

--- a/src/components/ui/PrivacyDialog.tsx
+++ b/src/components/ui/PrivacyDialog.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Modal } from './Modal';
+import { Button } from './Button';
+
+interface Props {
+  isOpen: boolean;
+  onAccept: () => void;
+}
+
+export function PrivacyDialog({ isOpen, onAccept }: Props) {
+  return (
+    <Modal isOpen={isOpen} onClose={() => {}} title="Política de Privacidad" showCloseButton={false}>
+      <div className="space-y-4">
+        <p className="text-sm text-gray-700 dark:text-gray-300">
+          Para continuar debes aceptar nuestra política de privacidad.
+        </p>
+        <div className="text-right">
+          <Button onClick={onAccept}>Aceptar</Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+export function useTheme() {
+  const getInitial = (): 'light' | 'dark' => {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'light' || stored === 'dark') return stored as 'light' | 'dark';
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  };
+
+  const [theme, setTheme] = useState<'light' | 'dark'>(getInitial);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(t => (t === 'dark' ? 'light' : 'dark'));
+
+  return { theme, toggleTheme };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+html {
+  @apply transition-colors duration-300;
+}
+
+body {
+  @apply bg-white text-gray-900;
+}
+
+.dark body {
+  @apply bg-gray-900 text-gray-100;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,8 @@
+const storedTheme = localStorage.getItem('theme');
+if (storedTheme === 'dark' || (!storedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+  document.documentElement.classList.add('dark');
+}
+
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';

--- a/src/services/legalService.ts
+++ b/src/services/legalService.ts
@@ -1,0 +1,53 @@
+import { storageManager } from './storageManager';
+import { STORAGE_KEYS, APP_CONFIG, User } from '../types';
+
+export interface ConsentRecord {
+  userId: string;
+  acceptedAt: string;
+  version: string;
+  lang: string;
+}
+
+export const legalService = {
+  getConsent(userId: string): ConsentRecord | null {
+    return storageManager.get<ConsentRecord>(`wmapp_consent_${userId}`);
+  },
+
+  saveConsent(userId: string, lang: string) {
+    const record: ConsentRecord = {
+      userId,
+      acceptedAt: new Date().toISOString(),
+      version: APP_CONFIG.VERSION,
+      lang,
+    };
+    storageManager.set(`wmapp_consent_${userId}`, record);
+  },
+
+  downloadUserData(userId: string): string {
+    const result: Record<string, any> = {};
+    Object.values(STORAGE_KEYS).forEach(key => {
+      const value = storageManager.get<any>(key);
+      if (!value) return;
+      if (Array.isArray(value)) {
+        const filtered = value.filter((v: any) => v.userId === userId || v.id === userId || v.user?.id === userId);
+        if (filtered.length) result[key] = filtered;
+      } else if (value.userId === userId || value.user?.id === userId) {
+        result[key] = value;
+      }
+    });
+    return JSON.stringify({
+      version: APP_CONFIG.VERSION,
+      exportedAt: new Date().toISOString(),
+      userId,
+      data: result,
+    }, null, 2);
+  },
+
+  deleteAccount(userId: string): void {
+    const users = storageManager.get<User[]>(STORAGE_KEYS.USERS, []);
+    storageManager.set(STORAGE_KEYS.USERS, users.filter(u => u.id !== userId));
+    storageManager.clearUserData(userId);
+    storageManager.remove(STORAGE_KEYS.SESSION);
+    storageManager.remove(`wmapp_consent_${userId}`);
+  }
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- enable Tailwind dark mode
- create theme hook with persistent toggle
- implement dark styles across layout and UI
- add privacy consent dialog and legal service
- allow exporting personal data and deleting account

## Testing
- `npm run lint` *(fails: Cannot read properties of undefined (reading 'allowShortCircuit'))*

------
https://chatgpt.com/codex/tasks/task_e_6863f170338c8330b53900a4c999df1e