### PR TITLE
Add regional rules with auto detection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { LeavesScreen } from './components/screens/LeavesScreen';
 import { ReportsScreen } from './components/screens/ReportsScreen';
 import { NotificationsScreen } from './components/screens/NotificationsScreen';
 import { SettingsScreen } from './components/screens/SettingsScreen';
+import { PolicyScreen } from './components/screens/PolicyScreen';
 
 // ==========================================
 // COMPONENTE PRINCIPAL DE LA APLICACIÓN
@@ -51,6 +52,8 @@ function AppContent() {
         return <LeavesScreen />;
       case 'reports':
         return <ReportsScreen />;
+      case 'policy':
+        return <PolicyScreen />;
       case 'settings':
         return <SettingsScreen />;
       case 'notifications':
@@ -123,7 +126,7 @@ function getModeColors(mode: string): string {
 function getModeMessage(mode: string): string {
   switch (mode) {
     case 'demo':
-      return '🎯 MODO DEMO - Datos de prueba activos • Los cambios no se guardan permanentemente';
+      return 'Modo DEMO – algunas configuraciones están simuladas';
     case 'debug':
       return '🐛 MODO DEBUG - Herramientas de desarrollo activas • Solo para desarrollo';
     case 'production':

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -5,8 +5,9 @@ import {
   Users, 
   MapPin, 
   Calendar, 
-  BarChart3, 
-  Settings, 
+  BarChart3,
+  Settings,
+  Shield,
   LogOut,
   Bell,
   Menu,
@@ -15,13 +16,14 @@ import {
 import { Button } from '../ui/Button';
 import { Badge } from '../ui/Badge';
 import { useApp } from '../../contexts/AppContext';
+import { regionConfig } from '../../regionConfig';
 
 interface MainLayoutProps {
   children: React.ReactNode;
 }
 
 export function MainLayout({ children }: MainLayoutProps) {
-  const { state, logout, navigateTo, clearAllNotifications } = useApp();
+  const { state, logout, navigateTo, clearAllNotifications, setRegionCode } = useApp();
   const [sidebarOpen, setSidebarOpen] = React.useState(false);
 
   const navigation = [
@@ -31,6 +33,7 @@ export function MainLayout({ children }: MainLayoutProps) {
     { name: 'Estaciones', icon: MapPin, screen: 'stations', roles: ['admin', 'manager'] },
     { name: 'Ausencias', icon: Calendar, screen: 'leaves', roles: ['admin', 'manager', 'employee'] },
     { name: 'Reportes', icon: BarChart3, screen: 'reports', roles: ['admin', 'manager'] },
+    { name: 'Política', icon: Shield, screen: 'policy', roles: ['admin', 'manager', 'employee'] },
     { name: 'Configuración', icon: Settings, screen: 'settings', roles: ['admin', 'manager', 'employee'] },
   ];
 
@@ -161,6 +164,24 @@ export function MainLayout({ children }: MainLayoutProps) {
                 <span className="text-sm text-gray-600 hidden sm:inline">
                   {state.isOnline ? 'En línea' : 'Sin conexión'}
                 </span>
+              </div>
+
+              {/* Region selector */}
+              <div className="flex items-center space-x-2">
+                <img
+                  src={`https://flagcdn.com/w20/${state.regionCode.toLowerCase()}.png`}
+                  alt={state.regionCode}
+                  className="w-5 h-3"
+                />
+                <select
+                  value={state.regionCode}
+                  onChange={(e) => setRegionCode(e.target.value)}
+                  className="text-sm border rounded px-1 py-0.5"
+                >
+                  {Object.keys(regionConfig).map(code => (
+                    <option key={code} value={code}>{code}</option>
+                  ))}
+                </select>
               </div>
 
               {/* Sync status */}

--- a/src/components/screens/ClockInScreen.tsx
+++ b/src/components/screens/ClockInScreen.tsx
@@ -19,6 +19,7 @@ import { useApp } from '../../contexts/AppContext';
 import { useClockIns, useStations } from '../../hooks/useData';
 import { qrEngine } from '../../services/qrEngine';
 import { storageManager } from '../../services/storageManager';
+import { validateClockIn } from '../../services/policyService';
 
 export function ClockInScreen() {
   const { state, showNotification } = useApp();
@@ -212,6 +213,11 @@ export function ClockInScreen() {
       notes: `Fichaje manual desde ${station.name}`
     };
 
+    const warnings = validateClockIn(clockIns || [], { ...clockInData, id: '' } as any, state.regionCode);
+    warnings.forEach(w =>
+      showNotification({ type: 'warning', title: 'Advertencia', message: w })
+    );
+
     const result = await createClockIn(clockInData);
     
     if (result) {
@@ -256,6 +262,11 @@ export function ClockInScreen() {
       isManualEntry: false,
       notes: `Fichaje QR desde ${scanResult.station.name}`
     };
+
+    const warnings = validateClockIn(clockIns || [], { ...clockInData, id: '' } as any, state.regionCode);
+    warnings.forEach(w =>
+      showNotification({ type: 'warning', title: 'Advertencia', message: w })
+    );
 
     const result = await createClockIn(clockInData);
     

--- a/src/components/screens/PolicyScreen.tsx
+++ b/src/components/screens/PolicyScreen.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/Card';
+import { Badge } from '../ui/Badge';
+import { useApp } from '../../contexts/AppContext';
+import { regionConfig } from '../../regionConfig';
+
+export function PolicyScreen() {
+  const { state } = useApp();
+  const rules = regionConfig[state.regionCode] || regionConfig.ES;
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold text-gray-900">Política Laboral</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Reglas para {state.regionCode}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p>Zona horaria: {rules.timezone}</p>
+          <p>Máximo horas por jornada: {rules.maxHoursPerDay}</p>
+          <p>Descanso mínimo entre jornadas: {rules.minRestHours} h</p>
+          <p>Fichaje manual: {rules.manualAllowed ? 'Permitido' : 'No permitido'}</p>
+        </CardContent>
+      </Card>
+      {state.appMode.mode === 'demo' && (
+        <Badge variant="info">Modo DEMO – algunas configuraciones están simuladas</Badge>
+      )}
+    </div>
+  );
+}

--- a/src/regionConfig.ts
+++ b/src/regionConfig.ts
@@ -1,0 +1,31 @@
+export interface RegionRules {
+  timezone: string;
+  maxHoursPerDay: number;
+  minRestHours: number;
+  manualAllowed: boolean;
+  holidays: string[];
+}
+
+export const regionConfig: Record<string, RegionRules> = {
+  ES: {
+    timezone: 'Europe/Madrid',
+    maxHoursPerDay: 9,
+    minRestHours: 12,
+    manualAllowed: false,
+    holidays: [],
+  },
+  IN: {
+    timezone: 'Asia/Kolkata',
+    maxHoursPerDay: 10,
+    minRestHours: 10,
+    manualAllowed: true,
+    holidays: [],
+  },
+  US: {
+    timezone: 'America/New_York',
+    maxHoursPerDay: 12,
+    minRestHours: 8,
+    manualAllowed: true,
+    holidays: [],
+  },
+};

--- a/src/services/policyService.ts
+++ b/src/services/policyService.ts
@@ -1,0 +1,58 @@
+import { ClockIn } from '../types';
+import { getRegionRules } from './regionService';
+
+export function validateClockIn(
+  clockIns: ClockIn[],
+  newClockIn: ClockIn,
+  regionCode: string
+): string[] {
+  const rules = getRegionRules(regionCode);
+  const warnings: string[] = [];
+
+  if (!rules.manualAllowed && newClockIn.method === 'manual') {
+    warnings.push('El fichaje manual no está permitido en esta región');
+  }
+
+  const dateStr = newClockIn.timestamp.split('T')[0];
+  const dayRecords = clockIns
+    .filter(c => c.userId === newClockIn.userId && c.timestamp.startsWith(dateStr));
+  const sorted = [...dayRecords, newClockIn].sort(
+    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+  );
+
+  let inTime: Date | null = null;
+  let workedMs = 0;
+
+  for (const c of sorted) {
+    if (c.type === 'in') {
+      inTime = new Date(c.timestamp);
+    } else if (c.type === 'out' && inTime) {
+      workedMs += new Date(c.timestamp).getTime() - inTime.getTime();
+      inTime = null;
+    }
+  }
+
+  if (workedMs / 3600000 > rules.maxHoursPerDay) {
+    warnings.push(
+      `Has superado el máximo de ${rules.maxHoursPerDay} horas por jornada`
+    );
+  }
+
+  if (newClockIn.type === 'in') {
+    const lastOut = clockIns
+      .filter(c => c.userId === newClockIn.userId && c.type === 'out')
+      .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())[0];
+    if (lastOut) {
+      const diffH =
+        (new Date(newClockIn.timestamp).getTime() - new Date(lastOut.timestamp).getTime()) /
+        3600000;
+      if (diffH < rules.minRestHours) {
+        warnings.push(
+          `Debes descansar al menos ${rules.minRestHours} horas entre jornadas`
+        );
+      }
+    }
+  }
+
+  return warnings;
+}

--- a/src/services/regionService.ts
+++ b/src/services/regionService.ts
@@ -1,0 +1,38 @@
+import { regionConfig, RegionRules } from '../regionConfig';
+
+const REGION_OVERRIDE_KEY = 'regionOverride';
+const AUTO_REGION_KEY = 'autoRegion';
+
+export async function detectCountry(): Promise<string> {
+  try {
+    const res = await fetch('https://ipapi.co/json/');
+    if (!res.ok) throw new Error('Request failed');
+    const data = await res.json();
+    return data.country_code || 'ES';
+  } catch (error) {
+    console.warn('[regionService] Failed to detect country', error);
+    return 'ES';
+  }
+}
+
+export async function getRegionCode(): Promise<string> {
+  const override = localStorage.getItem(REGION_OVERRIDE_KEY);
+  if (override) return override;
+  const cached = localStorage.getItem(AUTO_REGION_KEY);
+  if (cached) return cached;
+  const detected = await detectCountry();
+  localStorage.setItem(AUTO_REGION_KEY, detected);
+  return detected;
+}
+
+export function setRegionOverride(code: string) {
+  localStorage.setItem(REGION_OVERRIDE_KEY, code);
+}
+
+export function clearRegionOverride() {
+  localStorage.removeItem(REGION_OVERRIDE_KEY);
+}
+
+export function getRegionRules(code: string): RegionRules {
+  return regionConfig[code] || regionConfig.ES;
+}


### PR DESCRIPTION
## Summary
- detect user country using ipapi and store region
- manage region overrides and configs
- enforce basic labor policy rules when clocking in
- show flag and region selector in layout
- add Labor Policy screen
- update demo banner text

## Testing
- `npm run lint` *(fails: Cannot read properties of undefined (reading 'allowShortCircuit'))*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863f7834fd4833082b7ddeffd4e3014